### PR TITLE
Fix symfony/process dependency to version 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
   "require": {
     "php": ">=7.1",
     "spatie/laravel-backup": "~5.0",
+    "symfony/process": "^3.4",
     "spatie/flysystem-dropbox": "^1.0",
     "league/flysystem-webdav": "~1.0"
   }


### PR DESCRIPTION
Keeping the Symfony dependencies explicitly in line with Laravel 5.5 solves #22.